### PR TITLE
Get more error messages

### DIFF
--- a/example/config_expose_errors.yml
+++ b/example/config_expose_errors.yml
@@ -1,0 +1,30 @@
+in:
+  type: file
+  path_prefix: example/example.csv
+  parser:
+    type: csv
+    charset: UTF-8
+    newline: CRLF
+    null_string: 'NULL'
+    skip_header_lines: 1
+    comment_line_marker: '#'
+    columns:
+      - {name: date,        type: string}
+      - {name: timestamp,   type: timestamp, format: "%Y-%m-%d %H:%M:%S.%N", timezone: "+09:00"}
+      - {name: "null",      type: string}
+      - {name: long,        type: long}
+      - {name: string,      type: string}
+      - {name: double,      type: double}
+      - {name: boolean,     type: boolean}
+out:
+  type: bigquery
+  mode: replace
+  auth_method: json_key
+  json_keyfile: /tmp/your-project-000.json
+  dataset: your_dataset_name
+  table: your_table_name
+  source_format: NEWLINE_DELIMITED_JSON
+  compression: NONE
+  auto_create_dataset: true
+  auto_create_table: true
+  schema_file: example/schema_expose_errors.json

--- a/example/schema_expose_errors.json
+++ b/example/schema_expose_errors.json
@@ -1,0 +1,30 @@
+[
+  {
+    "name":"dat",
+    "type":"STRING"
+  },
+  {
+    "name":"timestamp",
+    "type":"TIMESTAMP"
+  },
+  {
+    "name":"null",
+    "type":"STRING"
+  },
+  {
+    "name":"long",
+    "type":"INTEGER"
+  },
+  {
+    "name":"string",
+    "type":"STRING"
+  },
+  {
+    "name":"double",
+    "type":"FLOAT"
+  },
+  {
+    "name":"boolean",
+    "type":"BOOLEAN"
+  }
+]

--- a/lib/embulk/output/bigquery/bigquery_client.rb
+++ b/lib/embulk/output/bigquery/bigquery_client.rb
@@ -261,12 +261,12 @@ module Embulk
             end
           end
 
-          if error_result = _response.status.error_result
+          unless (_errors = _response.status.errors).empty?
             Embulk.logger.error {
               "embulk-output-bigquery: get_job(#{@project}, #{job_id}), " \
-              "error_result:#{error_result.to_h}"
+              "errors:#{_errors.map(&:to_h)}"
             }
-            raise Error, "failed during waiting a job, error_result:#{error_result.to_h}"
+            raise Error, "failed during waiting a job, errors:#{_errors.map(&:to_h)}"
           end
 
           _response

--- a/lib/embulk/output/bigquery/bigquery_client.rb
+++ b/lib/embulk/output/bigquery/bigquery_client.rb
@@ -261,7 +261,10 @@ module Embulk
             end
           end
 
-          unless (_errors = _response.status.errors).empty?
+          # cf. http://www.rubydoc.info/github/google/google-api-ruby-client/Google/Apis/BigqueryV2/JobStatus#errors-instance_method
+          # `errors` returns Array<Google::Apis::BigqueryV2::ErrorProto> if any error exists.
+          # Otherwise, this returns nil.
+          if _errors = _response.status.errors
             Embulk.logger.error {
               "embulk-output-bigquery: get_job(#{@project}, #{job_id}), " \
               "errors:#{_errors.map(&:to_h)}"


### PR DESCRIPTION
@sonots 
I changed the way to log unknown errors.
This change makes messages more specific and clearer.(see below)

**before**

```
2016-03-03 14:53:00.497 +0900 [ERROR] (Ruby-0-Thread-10: /Users/takahiro.nakayama/src/github.com/civitaspo/embulk-output-bigquery/lib/embulk/output/bigquery/bigquery_client.rb:113): embulk-output-bigquery: get_job(test-project, job_7omBY31MzcHdmfIcrjmJ9NAFkbo), error_result:{:reason=>"invalid", :message=>"Too many errors encountered. Limit is: 0."}
```

**after**

```
2016-03-03 14:15:39.163 +0900 [ERROR] (Ruby-0-Thread-11: /Users/takahiro.nakayama/src/github.com/civitaspo/embulk-output-bigquery/lib/embulk/output/bigquery/bigquery_client.rb:113): embulk-output-bigquery: get_job(test-project, job_XADxfocr01Nd9gNReVcj5vH2fmA), errors:[{:reason=>"invalid", :location=>"File: 0 / Offset:0 / Line:1 / Column:7 / Field:date", :message=>"no such field"}, {:reason=>"invalid", :location=>"File: 0 / Offset:119 / Line:2 / Column:7 / Field:date", :message=>"no such field"}, {:reason=>"invalid", :location=>"File: 0 / Offset:238 / Line:3 / Column:7 / Field:date", :message=>"no such field"}, {:reason=>"invalid", :location=>"File: 0 / Offset:358 / Line:4 / Column:7 / Field:date", :message=>"no such field"}, {:reason=>"invalid", :message=>"Too many errors encountered. Limit is: 0."}]
```
